### PR TITLE
Fix go 1.17 build tag

### DIFF
--- a/simple.bpf.c
+++ b/simple.bpf.c
@@ -1,3 +1,4 @@
+//go:build ignore
 //+build ignore
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h> 

--- a/simple.bpf.c
+++ b/simple.bpf.c
@@ -1,7 +1,8 @@
 //go:build ignore
-//+build ignore
+// +build ignore
+
 #include "vmlinux.h"
-#include <bpf/bpf_helpers.h> 
+#include <bpf/bpf_helpers.h>
 #include "simple.h"
 
 struct {


### PR DESCRIPTION
This update uses the new Go build tag syntax (`go:build`) to ignore the `simple.bpf.c` file during build. It does this in a way which is backwards-compatible with previous Go versions.

Tested Go versions:

- 1.17
- 1.16
- 1.15

Closes #4 